### PR TITLE
Pull Out Function for creating new contracts

### DIFF
--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -1,7 +1,7 @@
 use super::schema::block;
 use super::schema::{contracts, cw20_balances, dao, gov_token};
 use bigdecimal::BigDecimal; // Has to match diesel's version!
-// use cosmrs::proto::cosmwasm::wasm::v1::MsgInstantiateContract;
+                            // use cosmrs::proto::cosmwasm::wasm::v1::MsgInstantiateContract;
 use cosmrs::cosmwasm::MsgInstantiateContract;
 use cw3_dao::msg::GovTokenInstantiateMsg;
 use diesel::sql_types::{BigInt, Jsonb, Numeric, Text};
@@ -11,23 +11,23 @@ use std::fmt::Debug;
 #[derive(Insertable, Debug)]
 #[table_name = "contracts"]
 pub struct NewContract<'a> {
-    pub address: String,
-    pub staking_contract_address: String,
+    pub address: &'a str,
+    pub staking_contract_address: &'a str,
     pub code_id: i64,
     pub creator: String,
     pub admin: String,
-    pub label: String,
+    pub label: &'a str,
     pub creation_time: &'a str,
     pub height: BigDecimal,
 }
 
 impl<'a> NewContract<'a> {
     pub fn from_msg(
-        address: String,
-        staking_contract_address: String,
+        address: &'a str,
+        staking_contract_address: &'a str,
         creator: String,
         admin: String,
-        label: String,
+        label: &'a str,
         tx_height: BigDecimal,
         msg: &'a MsgInstantiateContract,
     ) -> NewContract<'a> {

--- a/src/indexing/msg_instantiate_contract.rs
+++ b/src/indexing/msg_instantiate_contract.rs
@@ -33,7 +33,10 @@ impl IndexMessage for MsgInstantiateContract {
     }
 }
 
-fn create_new_contract<'a>(msg_inst_contract: &'a MsgInstantiateContract, events: &'a std::collections::BTreeMap<String, Vec<String>>) -> Result<NewContract<'a>, anyhow::Error> {
+fn create_new_contract<'a>(
+    msg_inst_contract: &'a MsgInstantiateContract,
+    events: &'a std::collections::BTreeMap<String, Vec<String>>,
+) -> Result<NewContract<'a>, anyhow::Error> {
     let contract_addresses = get_contract_addresses(events);
     let contract_address = contract_addresses
         .contract_address
@@ -63,17 +66,28 @@ fn create_new_contract<'a>(msg_inst_contract: &'a MsgInstantiateContract, events
         "".to_string()
     };
     let creator = msg_inst_contract.sender.to_string();
-    let label = msg_inst_contract.label.clone().unwrap_or_default();
+    let mut label = "";
+    if let Some(contract_label) = &msg_inst_contract.label {
+        label = contract_label;
+    }
     // Dont need to clone contract and staking address
-    let contract_model = NewContract::from_msg(contract_address.to_string(), staking_contract_address.to_string(), creator, admin, label, tx_height, msg_inst_contract);
+    let contract_model = NewContract::from_msg(
+        contract_address,
+        staking_contract_address,
+        creator,
+        admin,
+        label,
+        tx_height,
+        msg_inst_contract,
+    );
     Ok(contract_model)
 }
 
 #[cfg(test)]
 mod tests {
-    use cosmrs::{cosmwasm::MsgInstantiateContract, AccountId};
     use crate::indexing::event_map::EventMap;
     use crate::indexing::msg_instantiate_contract::create_new_contract;
+    use cosmrs::{cosmwasm::MsgInstantiateContract, AccountId};
 
     #[test]
     fn test_new_contract_no_events_fails() {
@@ -84,10 +98,10 @@ mod tests {
         let msg_inst_contract = MsgInstantiateContract {
             sender: test_acc_id,
             admin: None,
-            code_id: 69 as u64,
+            code_id: 69,
             label: None,
             msg: Vec::new(),
-            funds: Vec::new(),            
+            funds: Vec::new(),
         };
 
         let empty_event_map = EventMap::new();

--- a/src/indexing/tx.rs
+++ b/src/indexing/tx.rs
@@ -3,12 +3,11 @@ use super::index_message::IndexMessage;
 use super::indexer_registry::IndexerRegistry;
 use super::msg_set::MsgSet;
 use anyhow::anyhow;
+use cosmrs::cosmwasm::MsgInstantiateContract;
 use cosmrs::proto::cosmos::bank::v1beta1::MsgSend;
 use cosmrs::proto::cosmwasm::wasm::v1::{
-    MsgExecuteContract,
-    MsgInstantiateContract as ProtoMsgInstContrct
+    MsgExecuteContract, MsgInstantiateContract as ProtoMsgInstContrct,
 };
-use cosmrs::cosmwasm::MsgInstantiateContract;
 use cosmrs::tx::{MsgProto, Tx};
 use log::{debug, error};
 use prost_types::Any;
@@ -54,13 +53,19 @@ pub fn process_messages(
                                 return msg_inst_contract.index_message(registry, events);
                             }
                             Err(e) => {
-                                error!("error parsing MsgInstantiateContract, events: {:?}", events);
+                                error!(
+                                    "error parsing MsgInstantiateContract, events: {:?}",
+                                    events
+                                );
                                 return Err(anyhow!(e));
                             }
                         }
                     }
                     Err(e) => {
-                        error!("error parsing ProstMsgInstantiateContract, events: {:?}", events);
+                        error!(
+                            "error parsing ProstMsgInstantiateContract, events: {:?}",
+                            events
+                        );
                         return Err(anyhow!(e));
                     }
                 }

--- a/src/util/contract_util.rs
+++ b/src/util/contract_util.rs
@@ -6,16 +6,16 @@ use diesel::prelude::*;
 use log::error;
 
 #[derive(Debug)]
-pub struct ContractAddresses {
-    pub contract_address: Option<String>,
-    pub cw20_address: Option<String>,
-    pub staking_contract_address: Option<String>,
+pub struct ContractAddresses<'a> {
+    pub contract_address: Option<&'a str>,
+    pub cw20_address: Option<&'a str>,
+    pub staking_contract_address: Option<&'a str>,
 }
 
-pub fn get_contract_addresses(transaction_events: &EventMap) -> ContractAddresses {
-    let mut contract_address = None;
-    let mut cw20_address = None;
-    let mut staking_contract_address = None;
+pub fn get_contract_addresses<'a>(transaction_events: &'a EventMap) -> ContractAddresses<'a> {
+    let mut contract_address: Option<&'a str> = None;
+    let mut cw20_address: Option<&'a str> = None;
+    let mut staking_contract_address: Option<&'a str> = None;
 
     if let Some(addr) = transaction_events.get("instantiate._contract_address") {
         // 0: DAO
@@ -24,14 +24,14 @@ pub fn get_contract_addresses(transaction_events: &EventMap) -> ContractAddresse
         // But if you use an existing token, you'll just get
         // DAO/staking contract
         if addr.len() == 3 {
-            contract_address = Some(addr[0].clone());
-            cw20_address = Some(addr[1].clone());
-            staking_contract_address = Some(addr[2].clone());
+            contract_address = Some(&addr[0]);
+            cw20_address = Some(&addr[1]);
+            staking_contract_address = Some(&addr[2]);
         } else if addr.len() == 2 {
-            contract_address = Some(addr[0].clone());
-            staking_contract_address = Some(addr[1].clone());
+            contract_address = Some(&addr[0]);
+            staking_contract_address = Some(&addr[1]);
         } else if addr.len() == 1 {
-            contract_address = Some(addr[0].clone());
+            contract_address = Some(&addr[0]);
         } else {
             error!("unexpected addr {:?}", addr);
         }

--- a/src/util/dao.rs
+++ b/src/util/dao.rs
@@ -31,8 +31,8 @@ pub fn insert_dao(
     if let GovTokenMsg::UseExistingCw20 { addr, label: _, .. } = gov_token {
         gta = addr.clone();
         gta_option = Some(&gta);
-    } else if let Some(cw20_address) = &contract_addr.cw20_address {
-        gta = cw20_address.clone();
+    } else if let Some(cw20_address) = contract_addr.cw20_address {
+        gta = cw20_address.to_string();
         gta_option = Some(&gta);
     }
 


### PR DESCRIPTION
Problem:
- It's really hard to test individual events, and message payloads and then see if the resultant behavior is occurring. (Given some set of events, is the DAO being created?).

Solution:
- Pull out function and use the MsgInstantiateCosmWasm object instead of using ProstObjects.